### PR TITLE
Backwards compatibility with math code blocks

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -2,24 +2,24 @@
 
 @font-face {
   font-family: "Computer Modern";
-  src: url('https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunss.otf');
+  src: url("https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunss.otf");
 }
 
 @font-face {
   font-family: "Computer Modern";
-  src: url('https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunsx.otf');
+  src: url("https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunsx.otf");
   font-weight: bold;
 }
 
 @font-face {
   font-family: "Computer Modern";
-  src: url('https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunsi.otf');
+  src: url("https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunsi.otf");
   font-style: italic, oblique;
 }
 
 @font-face {
   font-family: "Computer Modern";
-  src: url('https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunbxo.otf');
+  src: url("https://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunbxo.otf");
   font-weight: bold;
   font-style: italic, oblique;
 }
@@ -52,7 +52,11 @@ a {
   @apply underline;
 }
 
-.math {
+.math.display {
+  @apply font-math my-2 text-center w-full;
+}
+
+.math.inline {
   @apply font-math;
 }
 


### PR DESCRIPTION
- **style: selection colors**
- **feat: pdf, md, and tex file downloads with pandoc**
- **docs: include installation notes**
- **feat: math fonts**
- **fix: fonts**
- **fix: backwards compatibility with rani's code as math**
